### PR TITLE
qemu: update to 7.2.5

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,11 +1,11 @@
 name       : qemu
-version    : 7.2.4
-release    : 58
+version    : 7.2.5
+release    : 59
 source     :
-    - https://download.qemu.org/qemu-7.2.4.tar.xz : ce7f94e51b4cddefacf1f434834fd3310284aa04e4b75509b4ee18af3ba2251d
+    - https://download.qemu.org/qemu-7.2.5.tar.xz : 172042aa37609240130fe03f5925001e717d74dbd0799adf15b15dc038aef9d1
 license    : GPL-2.0-only
-component  : virt
 homepage   : https://wiki.qemu.org/Main_Page
+component  : virt
 summary    : QEMU is a generic and open source machine emulator and virtualizer.
 description: |
     QEMU is a generic and open source machine emulator and virtualizer.
@@ -16,6 +16,7 @@ description: |
 builddeps  :
     - pkgconfig(SDL2_image)
     - pkgconfig(alsa)
+    - pkgconfig(bzip2)
     - pkgconfig(fuse3)
     - pkgconfig(epoxy)
     - pkgconfig(gbm)
@@ -43,7 +44,6 @@ builddeps  :
     - pkgconfig(spice-server)
     - pkgconfig(virglrenderer)
     - pkgconfig(x11)
-    - bzip2-devel
     - libaio-devel
 rundeps    :
     - edk2-ovmf

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -170,9 +170,9 @@ When used as a virtualizer, QEMU achieves near native performances by executing 
         </Files>
     </Package>
     <History>
-        <Update release="58">
-            <Date>2023-07-12</Date>
-            <Version>7.2.4</Version>
+        <Update release="59">
+            <Date>2023-09-17</Date>
+            <Version>7.2.5</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
Full release notes available [here](https://www.mail-archive.com/qemu-devel@nongnu.org/msg981380.html)

**Security Fixes:**
- CVE-2023-3180
- CVE-2023-3354
- CVE-2023-0664
- CVE-2023-3255

**Test Plan:**
- Launched my existing VMs
- Created and launched new x64 and aarch64 VMs

### Checklist

- [x] Package was built and tested against unstable
